### PR TITLE
[페이먼츠 미션 Step 3] 코난(윤정민) 미션 제출합니다.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,11 @@
 import GlobalStyle from './GlobalStyle';
 import CardList from './pages/CardList';
 import CardRegistration from './pages/CardRegistration';
-import { useState } from 'react';
+import { Suspense, useState } from 'react';
 import { CardListProvider } from './contexts/CardListContexts';
 import CardAlias from './pages/CardAlias';
 import { PortalProvider } from './components/ModalPortal';
+import CardRegisterLoader from './pages/CardAlias/CardRegisterLoader';
 
 const enum PAGE {
   CARD_LIST = 'card-list',
@@ -29,7 +30,9 @@ function App() {
           />
         )}
         {page === PAGE.CARD_ALIAS && (
-          <CardAlias setPageCardList={() => setPage(PAGE.CARD_LIST)} currentId={currentId} />
+          <Suspense fallback={<CardRegisterLoader />}>
+            <CardAlias setPageCardList={() => setPage(PAGE.CARD_LIST)} currentId={currentId} />
+          </Suspense>
         )}
       </CardListProvider>
       <PortalProvider />

--- a/src/components/CardRegistrationForm/CardRegistrationForm.tsx
+++ b/src/components/CardRegistrationForm/CardRegistrationForm.tsx
@@ -213,7 +213,7 @@ const SubmitButton = styled.button`
   }
 `;
 
-const InputGroup = styled.p`
+const InputGroup = styled.div`
   position: relative;
 `;
 

--- a/src/pages/CardAlias/CardAlias.tsx
+++ b/src/pages/CardAlias/CardAlias.tsx
@@ -1,9 +1,11 @@
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import Card from '../../components/Card';
 import { useCardListContext } from '../../contexts/CardListContexts';
 import styled from 'styled-components';
 import { Input } from '../../components/Input';
 import Header from '../../components/Header';
+import PostResult from './PostResult';
+import { wrapPromise } from './wrapPromise';
 
 type CardAliasProps = {
   setPageCardList: () => void;
@@ -12,10 +14,28 @@ type CardAliasProps = {
 
 const CardAlias = ({ setPageCardList, currentId }: CardAliasProps) => {
   const { cardList, setCardList } = useCardListContext();
-  // TODO: 단언 없애려면 어떻게 로직을 분리하면 좋을지
+  // TODO: 단언 없애려면..? find는 애초에 undefined를 반환할 수 있다.
   const card = cardList.find(({ id }) => id === currentId)!;
+  const [postResource, setPostResource] = useState<any>({
+    result: {
+      read() {
+        return null;
+      },
+    },
+  });
 
   const aliasRef = useRef<HTMLInputElement>(null);
+
+  const postCard = () => {
+    const promise = new Promise((resolve, reject) => {
+      setTimeout(() => {
+        resolve('success');
+        setPageCardList();
+      }, 3000);
+    });
+
+    return wrapPromise(promise);
+  };
 
   const handleClickButton = () => {
     setCardList((prev) => {
@@ -27,7 +47,7 @@ const CardAlias = ({ setPageCardList, currentId }: CardAliasProps) => {
       });
     });
 
-    setPageCardList();
+    setPostResource({ result: postCard() });
   };
 
   return (
@@ -42,6 +62,7 @@ const CardAlias = ({ setPageCardList, currentId }: CardAliasProps) => {
       <Styled.ConfirmButton type="button" onClick={handleClickButton}>
         확인
       </Styled.ConfirmButton>
+      <PostResult resource={postResource} />
     </Styled.Wrapper>
   );
 };

--- a/src/pages/CardAlias/CardRegisterLoader.tsx
+++ b/src/pages/CardAlias/CardRegisterLoader.tsx
@@ -1,0 +1,60 @@
+import styled, { keyframes } from 'styled-components';
+
+const CardRegisterLoader = () => {
+  return (
+    <Styled.Layout>
+      <Styled.Wrapper>
+        <Styled.Loader />
+      </Styled.Wrapper>
+      <Styled.Message>카드를 등록중입니다.</Styled.Message>
+    </Styled.Layout>
+  );
+};
+
+export default CardRegisterLoader;
+
+const Layout = styled.div`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 40px;
+`;
+
+const Wrapper = styled.div`
+  width: 170px;
+  height: 100px;
+  background-color: #d9d9d9;
+  border-radius: 10px;
+`;
+
+const moveRight = keyframes`
+  0% {
+    transform: translateX(0%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+`;
+
+const Loader = styled.div`
+  width: 85px;
+  height: inherit;
+  background-color: #333333;
+  border-radius: 10px;
+  animation: ${moveRight} 1.5s ease-in-out infinite;
+`;
+
+const Message = styled.div`
+  color: #575757;
+  font-size: 14px;
+  font-weight: 700;
+`;
+
+const Styled = {
+  Layout,
+  Wrapper,
+  Loader,
+  Message,
+};

--- a/src/pages/CardAlias/PostResult.tsx
+++ b/src/pages/CardAlias/PostResult.tsx
@@ -1,0 +1,11 @@
+const PostResult = ({ resource }: { resource: { result: { read: () => null } } }) => {
+  const data = resource.result.read();
+
+  if (!data) {
+    return null;
+  }
+
+  return <div>the result of the post request: {JSON.stringify(data)}</div>;
+};
+
+export default PostResult;

--- a/src/pages/CardAlias/wrapPromise.ts
+++ b/src/pages/CardAlias/wrapPromise.ts
@@ -1,0 +1,34 @@
+const enum RESOURCE_STATUS {
+  PENDING = 'pending',
+  SUCCESS = 'success',
+  ERROR = 'error',
+}
+
+export function wrapPromise<T>(promise: Promise<T>) {
+  let status = RESOURCE_STATUS.PENDING;
+  let result: T;
+
+  const suspender = promise.then(
+    (response) => {
+      status = RESOURCE_STATUS.SUCCESS;
+      result = response;
+    },
+    (error) => {
+      status = RESOURCE_STATUS.ERROR;
+      result = error;
+    },
+  );
+
+  return {
+    read() {
+      switch (status) {
+        case RESOURCE_STATUS.PENDING:
+          throw suspender;
+        case RESOURCE_STATUS.ERROR:
+          throw result;
+        default:
+          return result;
+      }
+    },
+  };
+}


### PR DESCRIPTION
# Step3 - Refactoring & Reusability

> [배포페이지](https://cruelladevil.github.io/react-payments/)
> [NPM 페이지](https://www.npmjs.com/package/woowa-conan-modal)

마지막 Step3 미션은 React의 Suspense에 대해 공부해보고,
라이브러리를 직접 배포하면서 webpack 설정에 대해서 조금씩 공부해보는 시간이었던 것 같습니다.
아쉽게도 모달 배포가 제대로 되지 않아 타입추론이 제대로 되지 않는 이슈가 있습니다.

## 학습 목표

- [x] 사용하던 모달을 분리해서 npm으로 배포하기
- [ ] 배포한 모달을 직접 import해서 사용하기
- [ ] 문서로서 스토리북을 고도화하기 위해 리팩터링
- [x] '카드를 등록중입니다' 스피너 추가

## 기능 구현 사항

- 카드 등록 로더를 구현하였습니다.
- 사용중인 BottomSheet 모달을 NPM으로 배포하였습니다.

## 미구현 사항

- 배포된 모달이 타입 추론이 되지 않음.
- 배포된 모달이 원래 동작하던 방식대로 동작하지 않음.
- 스토리북을 추가적으로 고도화시키지 못하였습니다.

## 궁금한 점

### Suspense

비동기 fetch 과정에서 loading 상태와 error 상태를 컴포넌트 내부에서 정의하지 않고,
promise를 던져 컴포넌트 외부에서 catch하여 처리하는 방식으로
React에서는 최근 Suspense를 권장하고 있더라구요. (아직 발전하는 단계인 것 같긴 했습니다)

이번 구현에서 단순히 setTimeout으로 로더만 보여주고 넘어가는 방식으로 그치지 않고 Suspense를 활용해보고자 도입하였습니다.
다만 그 과정에서 Suspense는 fetch method가 GET일 때,
즉, 데이터를 가지고 올 때 가지고 오는 동안 fallback을 그려주고자 하는 것이 핵심이라는 것을 알게 되었습니다.

지금 적용하는 부분은 `카드를 등록중입니다.`라는 일종의 POST 메소드라고 예상되고,
fetch 과정으로 보여줄 데이터가 없기 때문에 임의로 PostResult라는 POST 요청 결과를 나타내는 컴포넌트를 만들어 Suspense를 적용하였습니다.

그렇기 때문에 이번 미션과 Suspense는 어울리지 않는다고 생각하는데,
POST 요청의 응답을 받는동안 그려줄 컴포넌트도 Suspense를 활용하는가요?